### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 - **MCP Retriever**: Retrieve MCP Servers using semantic search
 
+<a href="https://glama.ai/mcp/servers/8pg7mzcpt8"><img width="380" height="200" src="https://glama.ai/mcp/servers/8pg7mzcpt8/badge" alt="mcp-registry-server MCP server" /></a>
+
 ## Tools
 
 - **retrieve_mcps**


### PR DESCRIPTION
This PR adds a badge for the [mcp-registry-server](https://glama.ai/mcp/servers/8pg7mzcpt8) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/8pg7mzcpt8"><img width="380" height="200" src="https://glama.ai/mcp/servers/8pg7mzcpt8/badge" alt="mcp-registry-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.